### PR TITLE
Python jq fallback

### DIFF
--- a/last_green_commit.py
+++ b/last_green_commit.py
@@ -1,0 +1,12 @@
+#!/usr/bin/env python
+import sys
+import json
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+
+url = sys.argv[1]
+data = json.load(urlopen(url))
+print(data[0]['sha'])

--- a/last_green_commit.sh
+++ b/last_green_commit.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 : ${CI_SERVER_URL:-"https://gitlab.com"}
 
 DIRNAME="$(dirname $(readlink -f "$0"))"

--- a/last_green_commit.sh
+++ b/last_green_commit.sh
@@ -5,7 +5,12 @@ set -e
 DIRNAME="$(dirname $(readlink -f "$0"))"
 pushd ${DIRNAME}
 url="${CI_SERVER_URL}/api/v4/projects/${CI_PROJECT_ID}/pipelines?private_token=${PRIVATE_TOKEN}&status=success&ref=${CI_COMMIT_REF_NAME}"
-commit=$(curl -s ${url} | jq -r -f jq.filter)
+if [ $(which curl 2>/dev/null;) ] && [ $(which jq 2>/dev/null;) ]; then
+  commit=$(curl -s ${url} | jq -r -f jq.filter)
+else
+  echo "Missing curl or jq; using python fallback"
+  commit=$(${DIRNAME}/last_green_commit.py ${url})
+fi
 echo "Last green commit is '${commit}'."
 echo ${commit} > .LAST_GREEN_COMMIT
 popd


### PR DESCRIPTION
We couldn't depend on the presence of curl and jq in our ci environments, so added a python based fallback.

No worries if its not something that seems generally useful.